### PR TITLE
Automate asus stop

### DIFF
--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -103,6 +103,7 @@ namespace GHelper
             labelSettings = new Label();
             panelSettings = new Panel();
             checkAutoToggleClamshellMode = new CheckBox();
+            checkAutoToggleStopAsusApps = new CheckBox();
             checkTopmost = new CheckBox();
             checkNoOverdrive = new CheckBox();
             checkUSBC = new CheckBox();
@@ -1060,6 +1061,7 @@ namespace GHelper
             panelSettings.AccessibleRole = AccessibleRole.Grouping;
             panelSettings.AutoSize = true;
             panelSettings.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            panelSettings.Controls.Add(checkAutoToggleStopAsusApps);
             panelSettings.Controls.Add(checkAutoToggleClamshellMode);
             panelSettings.Controls.Add(checkTopmost);
             panelSettings.Controls.Add(checkNoOverdrive);
@@ -1085,6 +1087,18 @@ namespace GHelper
             checkAutoToggleClamshellMode.TabIndex = 8;
             checkAutoToggleClamshellMode.Text = "Auto Toggle Clamshell Mode";
             checkAutoToggleClamshellMode.UseVisualStyleBackColor = true;
+            // 
+            // checkAutoToggleStopAsusApps
+            // 
+            checkAutoToggleStopAsusApps.AutoSize = true;
+            checkAutoToggleStopAsusApps.Dock = DockStyle.Top;
+            checkAutoToggleStopAsusApps.Location = new Point(20, 257);
+            checkAutoToggleStopAsusApps.Name = "checkAutoToggleStopAsusApps";
+            checkAutoToggleStopAsusApps.Padding = new Padding(3);
+            checkAutoToggleStopAsusApps.Size = new Size(952, 42);
+            checkAutoToggleStopAsusApps.TabIndex = 8;
+            checkAutoToggleStopAsusApps.Text = "Auto Toggle Stop Asus Apps on Lauch";
+            checkAutoToggleStopAsusApps.UseVisualStyleBackColor = true;
             // 
             // checkTopmost
             // 
@@ -1344,6 +1358,7 @@ namespace GHelper
         private Slider sliderBrightness;
         private PictureBox pictureLog;
         private CheckBox checkAutoToggleClamshellMode;
+        private CheckBox checkAutoToggleStopAsusApps;
         private Label labelFNE;
         private RComboBox comboFNE;
         private TextBox textFNE;

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -1097,7 +1097,7 @@ namespace GHelper
             checkAutoToggleStopAsusApps.Padding = new Padding(3);
             checkAutoToggleStopAsusApps.Size = new Size(952, 42);
             checkAutoToggleStopAsusApps.TabIndex = 8;
-            checkAutoToggleStopAsusApps.Text = "Auto Toggle Stop Asus Apps on Lauch";
+            checkAutoToggleStopAsusApps.Text = "Auto Toggle Stop Asus Apps on Launch";
             checkAutoToggleStopAsusApps.UseVisualStyleBackColor = true;
             // 
             // checkTopmost

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -404,7 +404,7 @@ namespace GHelper
 
         }
 
-        public void ServiesToggle()
+        public void ServicesToggle()
         {
             buttonServices.Enabled = false;
 
@@ -438,7 +438,7 @@ namespace GHelper
         private void ButtonServices_Click(object? sender, EventArgs e)
         {
             if (ProcessHelper.IsUserAdministrator())
-                ServiesToggle();
+                ServicesToggle();
             else
                 ProcessHelper.RunAsAdmin("services");
         }

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -119,6 +119,9 @@ namespace GHelper
             checkTopmost.Text = Properties.Strings.WindowTop;
             checkUSBC.Text = Properties.Strings.OptimizedUSBC;
             checkAutoToggleClamshellMode.Text = Properties.Strings.ToggleClamshellMode;
+            checkAutoToggleStopAsusApps.Text = 
+                Properties.Strings.ToggleStopAsusApps == "" ?
+                Properties.Strings.ToggleStopAsusApps : checkAutoToggleStopAsusApps.Text;
 
             labelBacklightKeyboard.Text = Properties.Strings.Keyboard;
             labelBacklightBar.Text = Properties.Strings.Lightbar;
@@ -285,6 +288,10 @@ namespace GHelper
             //checkAutoToggleClamshellMode.Visible = clamshellControl.IsExternalDisplayConnected();
             checkAutoToggleClamshellMode.Checked = AppConfig.Is("toggle_clamshell_mode");
             checkAutoToggleClamshellMode.CheckedChanged += checkAutoToggleClamshellMode_CheckedChanged;
+
+            //Auto Stop Asus Apps
+            checkAutoToggleStopAsusApps.Checked = AppConfig.Is("toggle_stopasusapps_mode");
+            checkAutoToggleStopAsusApps.CheckedChanged += checkAutoToggleStopAsusApps_CheckedChanged;
 
             checkTopmost.Checked = AppConfig.Is("topmost");
             checkTopmost.CheckedChanged += CheckTopmost_CheckedChanged; ;
@@ -573,6 +580,22 @@ namespace GHelper
             else
             {
                 ClamshellModeControl.DisableClamshellMode();
+            }
+
+        }
+        private void checkAutoToggleStopAsusApps_CheckedChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("toggle_stopasusapps_mode", checkAutoToggleStopAsusApps.Checked ? 1 : 0);
+
+            if (checkAutoToggleStopAsusApps.Checked)
+            {
+                //clamshellControl.ToggleLidAction();
+                //ToDo: Functionality that implements that StopAsusApps
+            }
+            else
+            {
+                //ClamshellModeControl.DisableClamshellMode();
+                //ToDo: Functionlity to disable stopasusapps
             }
 
         }

--- a/app/Helpers/StopAsusApps.cs
+++ b/app/Helpers/StopAsusApps.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GHelper.Helpers
+{
+    internal class StopAsusApps
+    {
+        public StopAsusApps() 
+        {
+            if (!IsStopAsusAppsEnabled())
+            {
+                return;
+            }
+            else
+            {
+                Extra keyb = new();
+                if (ProcessHelper.IsUserAdministrator())
+                    keyb.ServiesToggle();
+                else
+                    ProcessHelper.RunAsAdmin("services");
+            }
+        }
+        private bool IsStopAsusAppsEnabled()
+        {
+            return AppConfig.Is("toggle_stopasusapps_mode");
+        }
+    }
+}

--- a/app/Helpers/StopAsusApps.cs
+++ b/app/Helpers/StopAsusApps.cs
@@ -10,15 +10,17 @@ namespace GHelper.Helpers
     {
         public StopAsusApps() 
         {
+            int servicesCount = OptimizationService.GetRunningCount();
             if (!IsStopAsusAppsEnabled())
             {
                 return;
             }
-            else
+            else if (servicesCount > 0)
             {
                 Extra keyb = new();
-                if (ProcessHelper.IsUserAdministrator())
-                    keyb.ServiesToggle();
+                if (ProcessHelper.IsUserAdministrator() &&
+                    OptimizationService.IsRunning())
+                    keyb.ServicesToggle();
                 else
                     ProcessHelper.RunAsAdmin("services");
             }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -245,7 +245,7 @@ namespace GHelper
                     case "services":
                         settingsForm.keyb = new Extra();
                         settingsForm.keyb.Show();
-                        settingsForm.keyb.ServiesToggle();
+                        settingsForm.keyb.ServicesToggle();
                         break;
                     case "uv":
                         Startup.ReScheduleAdmin();

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -120,7 +120,7 @@ namespace GHelper
             {
                 SettingsToggle(action);
             }
-
+            StopAsusApps stopasusApps = new();
             Application.Run();
 
         }

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -1501,7 +1501,19 @@ namespace GHelper.Properties {
                 return ResourceManager.GetString("ToggleClamshellMode", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string for Toggle Stop Asus Apps similar to Auto Toggle Clamshell Mode.
+        /// </summary>
+        internal static string ToggleStopAsusApps
+        {
+            get
+            {
+                return ResourceManager.GetString("ToggleStopAsusApps", resourceCulture);
+            }
+        }
+
+
         /// <summary>
         ///   Looks up a localized string similar to Toggle Fn-Lock.
         /// </summary>


### PR DESCRIPTION
Merge in changes for automate stopping asus services on launch, provided a new setting in the extras profile settings.